### PR TITLE
Fixes #7,#5 via @MrLightningBlaze's edits

### DIFF
--- a/src/main/java/dev/jacksibley/slimeorigin/mixin/MixinLivingEntity.java
+++ b/src/main/java/dev/jacksibley/slimeorigin/mixin/MixinLivingEntity.java
@@ -1,8 +1,5 @@
 package dev.jacksibley.slimeorigin.mixin;
 
-
-import com.google.gson.JsonElement;
-import com.google.gson.JsonPrimitive;
 import dev.jacksibley.slimeorigin.Slimeorigin;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
@@ -68,10 +65,8 @@ public abstract class MixinLivingEntity extends Entity {
 
     private void revertScale()
     {
-        if (Optional.ofNullable(PehkuiConfig.DATA.get("keepScaleOnRespawn"))
-            .filter(JsonElement::isJsonPrimitive).map(JsonElement::getAsJsonPrimitive)
-            .filter(JsonPrimitive::isBoolean).map(JsonPrimitive::getAsBoolean)
-            .orElse(false)) {
+        PehkuiConfig pehconf = new PehkuiConfig();
+        if ((Boolean)Optional.ofNullable((Boolean)PehkuiConfig.COMMON.keepAllScalesOnRespawn.get()).orElse(false)) {
                 int flooredSlime = (int) floor(this.attributes.getValue(SLIME_SIZE));
                 if (flooredSlime != 0)
                 {

--- a/src/main/resources/data/slimeorigin/powers/fragmentation.json
+++ b/src/main/resources/data/slimeorigin/powers/fragmentation.json
@@ -10,6 +10,11 @@
     "command": "attribute @s slimeorigin:slime_size base set 0",
     "permission_level": 4
   },
+  "entity_action_respawned": {
+    "type": "origins:execute_command",
+    "command": "attribute @s slimeorigin:slime_size base set 3",
+    "permission_level": 4
+  },
   "execute_chosen_when_orb": true,
   "name": "Fragmentation",
   "description": "When others would die, you shrink to half your size. (Twice per life)"


### PR DESCRIPTION
This is a PR to fix the crashes caused by the Pehkui 2.0.0 breaking changes that have been causing crashes on slime origin death.
Thanks a lot for figuring this out @MrLightningBlaze!